### PR TITLE
Lead the home with the latest post, rename the projects heading, fix the Worker name

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ repositório:
 O `wrangler.jsonc` na raiz cuida do resto: serve `./build` como assets
 estáticos, mantém as URLs sem `.html` e usa o `404.html` gerado no build.
 
+O `name` no `wrangler.jsonc` tem que bater com o nome do Worker criado no
+painel — hoje `blog`. Um nome diferente ali faz o `wrangler deploy` publicar
+num Worker separado, e o Custom Domain está anexado a este.
+
 **Pages** — em **Workers & Pages → Create → Pages → Connect to Git**:
 
 | Campo | Valor |

--- a/src/lib/components/FeaturedPost.svelte
+++ b/src/lib/components/FeaturedPost.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import PostDate from './PostDate.svelte';
+	import CategoryPill from './categories/CategoryPill.svelte';
+
+	export let post;
+</script>
+
+<article
+	class="group relative overflow-hidden rounded-2xl border border-border bg-surface
+		transition-colors hover:border-brand/60 sm:flex"
+>
+	{#if post.coverImage}
+		<img
+			src={post.coverImage}
+			alt=""
+			decoding="async"
+			class="h-48 w-full object-cover sm:h-auto sm:w-2/5 sm:shrink-0"
+		/>
+	{/if}
+
+	<div class="p-6 sm:p-8">
+		{#if post.categories?.length}
+			<p class="font-mono text-xs uppercase tracking-[0.2em] text-accent">
+				{post.categories[0]}
+			</p>
+		{/if}
+
+		<h3 class="mt-3 font-display text-2xl font-bold leading-tight sm:text-3xl">
+			<!-- Stretched so the whole card is the click target. -->
+			<a href="/blog/{post.slug}" class="no-underline after:absolute after:inset-0">
+				<span class="transition-colors group-hover:text-accent">{post.title}</span>
+			</a>
+		</h3>
+
+		<PostDate date={post.date} class="mt-3 block font-mono text-xs text-faint" />
+
+		{#if post.excerpt}
+			<p class="mt-4 text-muted">{post.excerpt}</p>
+		{/if}
+
+		{#if post.categories?.length}
+			<!-- Above the stretched link so the pills stay clickable. -->
+			<div class="relative z-10 mt-5 flex flex-wrap gap-1.5">
+				{#each post.categories as category}
+					<CategoryPill name={category} href="/blog/category/{category}" />
+				{/each}
+			</div>
+		{/if}
+	</div>
+</article>

--- a/src/lib/components/PostsCompact.svelte
+++ b/src/lib/components/PostsCompact.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import PostDate from './PostDate.svelte';
+
+	export let posts = [];
+</script>
+
+<!-- Tight list for secondary posts: date and title only, separated by rules. -->
+<ul class="divide-y divide-border border-t border-border">
+	{#each posts as post}
+		<li>
+			<a
+				href="/blog/{post.slug}"
+				class="group flex flex-col gap-1 py-4 no-underline sm:flex-row sm:items-baseline sm:gap-5"
+			>
+				<PostDate
+					date={post.date}
+					class="shrink-0 whitespace-nowrap font-mono text-xs text-faint sm:w-40"
+				/>
+				<span class="font-medium text-text transition-colors group-hover:text-accent">
+					{post.title}
+				</span>
+			</a>
+		</li>
+	{/each}
+</ul>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,14 +1,20 @@
 <script lang="ts">
 	import { siteTitle, siteDescription, siteAuthor } from '$lib/config'
 	import { projects } from '$lib/projects'
-	import PostsList from '$lib/components/PostsList.svelte'
+	import FeaturedPost from '$lib/components/FeaturedPost.svelte'
+	import PostsCompact from '$lib/components/PostsCompact.svelte'
 	import ProjectRow from '$lib/components/ProjectRow.svelte'
 	import Resume from '$lib/components/Resume.svelte'
 	import LayoutContent from '$lib/components/layout/LayoutContent.svelte'
 
 	export let data
 
-	const featured = projects.slice(0, 3)
+	const featuredProjects = projects.slice(0, 3)
+
+	// The newest post gets the large treatment; the next three sit under it in
+	// the compact list.
+	$: latestPost = data.posts?.[0]
+	$: olderPosts = data.posts?.slice(1, 4) ?? []
 </script>
 
 <svelte:head>
@@ -43,19 +49,36 @@
 		</div>
 	</section>
 
-	{#if featured.length}
-		<section class="border-b border-border py-16 sm:py-24">
-			<div class="mb-14 flex items-end justify-between gap-6">
-				<div>
-					<p class="font-mono text-xs uppercase tracking-[0.2em] text-accent">
-						{featured.length} projetos
-					</p>
-					<h2 class="mt-3 text-3xl sm:text-4xl">No que tenho trabalhado</h2>
+	<section class="border-b border-border py-16 sm:py-20">
+		{#if latestPost}
+			<div class="mb-8 flex items-baseline justify-between gap-4">
+				<h2 class="text-3xl sm:text-4xl">Último post</h2>
+				<a href="/blog" class="whitespace-nowrap text-sm text-accent no-underline hover:underline">
+					Ver todos →
+				</a>
+			</div>
+
+			<FeaturedPost post={latestPost} />
+
+			{#if olderPosts.length}
+				<div class="mt-10">
+					<PostsCompact posts={olderPosts} />
 				</div>
+			{/if}
+		{:else}
+			<h2 class="text-3xl sm:text-4xl">Ainda não há posts por aqui</h2>
+			<p class="mt-3 text-muted">Volte em breve.</p>
+		{/if}
+	</section>
+
+	{#if featuredProjects.length}
+		<section class="border-b border-border py-16 sm:py-24">
+			<div class="mb-14">
+				<h2 class="text-3xl sm:text-4xl">Projetos pessoais</h2>
 			</div>
 
 			<ul class="flex flex-col gap-20 sm:gap-28">
-				{#each featured as project, i}
+				{#each featuredProjects as project, i}
 					<li>
 						<ProjectRow {...project} index={i + 1} />
 					</li>
@@ -64,21 +87,6 @@
 		</section>
 	{/if}
 
-	<section class="py-12 sm:py-16">
-		{#if data.posts?.length}
-			<div class="mb-6 flex items-baseline justify-between gap-4">
-				<h2 class="text-2xl">Últimos posts</h2>
-				<a href="/blog" class="whitespace-nowrap text-sm text-accent no-underline hover:underline">
-					Ver todos →
-				</a>
-			</div>
-
-			<PostsList posts={data.posts} />
-		{:else}
-			<h2 class="text-2xl">Ainda não há posts por aqui</h2>
-			<p class="mt-2 text-muted">Volte em breve.</p>
-		{/if}
-	</section>
 </LayoutContent>
 
 <Resume />

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,9 @@
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "wallynm-blog",
+	// Must match the Worker the dashboard created for this repo. A different
+	// name here would deploy to a second, separate Worker — and the Custom
+	// Domain below is attached to this one.
+	"name": "blog",
 	"compatibility_date": "2026-08-28",
 
 	// Custom Domain: the Worker becomes the origin for the hostname, and


### PR DESCRIPTION
Continuação depois do merge do [#2](https://github.com/wallynm/blog/pull/2), que já está no ar.

## Home

Os posts subiram para logo abaixo da introdução, antes dos projetos, e passaram a ter dois níveis:

- **`Último post`** — o mais recente em card grande: categoria, título, data, resumo e pills.
- Abaixo dele, os **três seguintes** numa lista compacta — só data e título, em linhas separadas por régua.

Antes os dez vinham depois dos projetos, todos no mesmo formato de card.

A lista compacta só renderiza quando existe mais de um post, então o site de hoje — com um post só — mostra o card em destaque e nada mais, em vez de uma régua vazia.

A ordem da home agora é: introdução → `Último post` → `Projetos pessoais` → currículo.

## Título dos projetos

Saiu o eyebrow `3 projetos` e o título `No que tenho trabalhado`. Ficou só **`Projetos pessoais`**.

## Nome do Worker

O Worker que o painel criou para este repositório chama-se `blog`; o `wrangler.jsonc` dizia `wallynm-blog`.

Só existe `blog` na conta, então o pipeline de Workers Builds está publicando sob o próprio nome e ignorando esse campo — mas um `wrangler deploy` rodado localmente respeitaria o config e publicaria num Worker separado, enquanto o Custom Domain de `wallynm.dev` está anexado ao `blog`. Alinhar o nome remove a divergência nos dois casos.

## Um bug encontrado na verificação

A coluna de data da lista compacta estava em `8rem`, e `11 de jul. de 2026` não cabe nisso a 12px — todas as datas quebravam em duas linhas. Passou para `10rem` com `whitespace-nowrap`.

## Verificação

Renderizado com um post e com cinco, para exercitar os dois estados da lista compacta. A auditoria de contraste — que mede as cores computadas no DOM, não a tabela de tokens — continua passando em todas as rotas nos dois temas. `pnpm build` sai com exit 0 e `eslint` limpo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdvVnZWgXDc5Nmczsy5Da3)_